### PR TITLE
Fix a wrong env variable default for config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://mtracker3:postgres@postgres:5432/mtracker3
       - REDIS_HOST=redis
-      - LOG_DIRECTORY=/opt/logs
+      - LOG_DIR=/opt/logs
       - PROXY_DEFAULT_PROXY
       - PROXY_URL
       - PROXY_METHOD
@@ -54,7 +54,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://mtracker3:postgres@postgres:5432/mtracker3
       - REDIS_HOST=redis
-      - LOG_DIRECTORY=/opt/logs
+      - LOG_DIR=/opt/logs
       - PROXY_DEFAULT_PROXY
       - PROXY_URL
       - PROXY_METHOD


### PR DESCRIPTION
Without this change, logs are being written to the default directory (i.e. `/tmp/logs`) instead of the preferred directory (`/opt/logs`)