### PR TITLE
Make mtracker API more uniform

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -444,7 +444,7 @@ class Bot:
 
     @property
     def name(self) -> str:
-        return f"{self.family}_{self.bot_id}_{self.country}"
+        return f"{self.family}_{self.tracker_id}_{self.country}"
 
     def serialize(self) -> Dict[str, Any]:
         return {

--- a/src/model.py
+++ b/src/model.py
@@ -615,11 +615,14 @@ class Bot:
 
     @staticmethod
     def fetch_by_tracker_id(
-        cur: cursor, tracker_id: int, limit: int = 100, start: int = 0
+        cur: cursor, tracker_id: int, status: Optional[Status] = None, limit: int = 100, start: int = 0
     ) -> List["Bot"]:
-        cur.execute(
-            "SELECT * FROM bots WHERE tracker_id=%s LIMIT %s OFFSET %s",
-            (tracker_id, limit, start),
+        cur.execute("""SELECT *
+            FROM bots
+            WHERE (status=%s OR %s is NULL)
+            AND tracker_id=%s
+            LIMIT %s OFFSET %s""",
+            (status, status, tracker_id, limit, start),
         )
         return [Bot(*x) for x in cur.fetchall()]
 
@@ -684,6 +687,7 @@ class Tracker:
         return {
             "trackerId": self.tracker_id,
             "mwdbId": self.config_hash,
+            "config": self.config,
             "name": self.name,
             "family": self.family,
             "status": self.status,

--- a/src/model.py
+++ b/src/model.py
@@ -444,13 +444,13 @@ class Bot:
 
     @property
     def name(self) -> str:
-        return f"{self.family}_{self.bot_id}"
+        return f"{self.family}_{self.bot_id}_{self.country}"
 
     def serialize(self) -> Dict[str, Any]:
         return {
             "botId": self.bot_id,
             "trackerId": self.tracker_id,
-            "trackerName": f"{self.family}@{self.tracker_id}",
+            "trackerName": f"{self.family}_{self.tracker_id}",
             "failingSpree": self.failing_spree,
             "status": self.status,
             "proxyCountry": self.country,
@@ -681,7 +681,7 @@ class Tracker:
 
     @property
     def name(self) -> str:
-        return f"{self.family}@{self.tracker_id}"
+        return f"{self.family}_{self.tracker_id}"
 
     def serialize(self) -> Dict[str, Any]:
         return {


### PR DESCRIPTION
Make API more uniform, and change entity names slightly;

* Now both bots and tracker API endpoints have fields "id", "name" and "family". Previously that was random
* Tracker names are now `family@id`, and bot names are now `family_id`. The reasoning is:
  * We don't use tracker name anywhere right now, so changing it is not a compatibility problem
  * Old tracker names in the API were inconsistent with bot names (id_family instead of family_id).
  * We use bot names in the web UI, but don't expose them in the API - this PR changes that
  * Finally, the names shouldn't be ambiguous so `_` is used for bots and `@` for trackers.