### PR TITLE
Also show status modal next to bots

### DIFF
--- a/src/templates/bot.html
+++ b/src/templates/bot.html
@@ -2,7 +2,7 @@
 
 {% from "macros/tasks.html" import tasks_table %}
 {% from "macros/utils.html" import showtime %}
-{% from "macros/status.html" import showlogs %}
+{% from "macros/status.html" import show_task_logs %}
 
 {% block content %}
 <h1 class="text-center">Bot {{entity.family}}_{{entity.bot_id}}</h1>
@@ -26,7 +26,7 @@
   <dt>status</dt>
   <dd>
     {% if tasks %}
-    {{showlogs(entity.status, tasks[0].task_id)}}
+    {{show_task_logs(entity.status, tasks[0].task_id)}}
     {% else %}
     {{entity.status}}
     {% endif %}

--- a/src/templates/layout.html
+++ b/src/templates/layout.html
@@ -45,12 +45,24 @@
         $(document).on("click", ".show-logs", function(e) {
             e.preventDefault();
 
+            // Only one of task-id and bot-id can be set
             var taskId = $(this).data("task-id");
+            var botId = $(this).data("bot-id");
+
+            var log_url;
+            if (taskId !== undefined) {
+              log_url = "/api/tasks/" + taskId + "/log";
+            } else if (botId !== undefined) {
+              log_url = "/api/bots/" + botId + "/log";
+            } else {
+              console.error("Either task-id or bot-id must be set");
+              return;
+            }
 
             $("#logContent").text("Loading...");
             $("#logModal").modal("show");
 
-            $.get("/api/tasks/" + taskId + "/log")
+            $.get(log_url)
                 .done(function(response) {
                     $("#logContent").text(response.data);
                 })

--- a/src/templates/macros/bots.html
+++ b/src/templates/macros/bots.html
@@ -1,5 +1,5 @@
 {% from "macros/utils.html" import showtime, cap_length, mtracker_url %}
-{% from "macros/status.html" import showlogs %}
+{% from "macros/status.html" import show_bot_last_logs %}
 
 {% macro bots_table(rows) %}
 <table class="table">
@@ -17,11 +17,7 @@
     <td><a href="{{url_for('bots', family=entity.family)}}">{{entity.family}}</a></td>
     <td>{{cap_length(entity.last_error, 60)}}</td>
     <td>
-      {% if entity.last_task_id %}
-        {{showlogs(entity.status, entity.last_task_id)}}
-      {% else %}
-        {{ entity.status }}
-      {% endif %}
+      {{show_bot_last_logs(entity.status, entity.bot_id)}}
       {% if entity.status == 'failing' %}({{entity.failing_spree}}){% endif %}
     </td>
     <td>

--- a/src/templates/macros/status.html
+++ b/src/templates/macros/status.html
@@ -16,14 +16,19 @@
 <a href="{{base}}?status={{statusname}}" class="{{ classnames[statusname] }}">{{statusname}}</a>
 {% endmacro %}
 
-{% macro showlogs(statusname, task_id, text=None) %}
+{% macro show_task_logs(statusname, task_id) -%}
 <a href="#"
    class="show-logs {{ classnames[statusname] }}"
    data-task-id="{{ task_id }}"
-   data-status="{{ statusname }}">
-   {{ text or statusname }}
-</a>
-{% endmacro %}
+   data-status="{{ statusname }}">{{ statusname }}</a>
+{%- endmacro %}
+
+{% macro show_bot_last_logs(statusname, bot_id) -%}
+<a href="#"
+   class="show-logs {{ classnames[statusname] }}"
+   data-bot-id="{{ bot_id }}"
+   data-status="{{ statusname }}">{{ statusname }}</a>
+{%- endmacro %}
 
 {% macro showstatusbtn(statusname) %}
 {% set active = request.args.get('status') == statusname %}

--- a/src/templates/macros/tasks.html
+++ b/src/templates/macros/tasks.html
@@ -1,13 +1,13 @@
 {% from "macros/utils.html" import showtime, cap_length %}
-{% from "macros/status.html" import showlogs %}
+{% from "macros/status.html" import show_task_logs %}
 
 {% macro tasks_table(rows) %}
 <table class="table">
   <tr>
-      <th>report time</th>
-      <th>bot</th>
-      <th>result</th>
-      <th>status</th>
+      <th class="col-md-2">report time</th>
+      <th class="col-md-2">bot</th>
+      <th class="col-md-4">status</th>
+      <th class="col-md-4">result</th>
   </tr>
   {% for entity in rows %}
   <tr>
@@ -20,7 +20,7 @@
       Fetched {{entity.results_no}} items
       {% endif %}
     </td>
-    <td>{{showlogs(entity.status, entity.task_id)}}</td>
+    <td>{{show_task_logs(entity.status, entity.task_id)}}</td>
   </tr>
   {% endfor %}
 </table>

--- a/src/templates/macros/trackers.html
+++ b/src/templates/macros/trackers.html
@@ -1,21 +1,21 @@
-{% from "macros/status.html" import showstatus, showlogs %}
+{% from "macros/status.html" import showstatus, show_bot_last_logs %}
 
 {% macro trackers_table(rows) %}
 <table class="table">
   <tr>
       <th class="col-md-1">tracker</th>
       <th class="col-md-2">family</th>
-      <th class="col-md-6">static config</th>
+      <th class="col-md-4">static config</th>
       <th class="col-md-3">bots</th>
   </tr>
   {% for entity in rows %}
   <tr>
-    <td><a href="{{url_for('tracker', tracker_id=entity.tracker_id)}}">{{entity.tracker_id}}</a></td>
+    <td><a href="{{url_for('tracker', tracker_id=entity.tracker_id)}}">{{entity.name}}</a></td>
     <td><a href="{{url_for('trackers', family=entity.family)}}">{{entity.family}}</a></td>
-    <td><a class="text-monospace" href="{{entity.config_url}}">{{entity.config_hash}}</a></td>
+    <td><a class="text-monospace" href="{{entity.config_url}}">{{entity.config_hash[:32]}}</a></td>
     <td>
       {% for bot in entity.bots %}
-      <a href="{{url_for('bot', bot_id=bot.bot_id)}}">{{showlogs(bot.status, bot.bot_id, text=bot.name)}}</a><br>
+      <a href="{{url_for('bot', bot_id=bot.bot_id)}}">{{bot.name}}</a> ({{show_bot_last_logs(bot.status, bot.bot_id)}})<br>
       {% endfor %}
     </td>
   </tr>

--- a/src/templates/task.html
+++ b/src/templates/task.html
@@ -1,7 +1,7 @@
 {% extends 'layout.html' %}
 {% from "macros/results.html" import results_table %}
 {% from "macros/utils.html" import showtime %}
-{% from "macros/status.html" import showlogs %}
+{% from "macros/status.html" import show_task_logs %}
 
 {% block content %}
 <h1 class="text-center">Task {{entity.task_id}}</h1>
@@ -14,7 +14,7 @@
   <dd>{{showtime(entity.report_time)}}</dd>
   
   <dt>status</dt>
-  <dd>{{showlogs(entity.status, entity.task_id)}}</dd>
+  <dd>{{show_task_logs(entity.status, entity.task_id)}}</dd>
 </dl>
 
 <h2>Results</h2>


### PR DESCRIPTION
Current bots table:

<img width="810" height="325" alt="image" src="https://github.com/user-attachments/assets/c29f9bdb-6f4d-476f-8642-688652973a0c" />

New bots table:

<img width="644" height="224" alt="image" src="https://github.com/user-attachments/assets/eeaad0e0-c440-4240-a82f-934e91ad19bf" />

Current trackers table (this was bugged! log was shown for task with task_id equal to checked bot_id):

<img width="1092" height="358" alt="image" src="https://github.com/user-attachments/assets/8885bb0b-d413-448a-9cea-b60fe639f702" />

New trackers table - the ability to quickly jump to a specific bot is still useful:

<img width="805" height="155" alt="image" src="https://github.com/user-attachments/assets/10177808-cdf5-4814-80d6-6ec837df17aa" />
